### PR TITLE
PR1: Fix incorrect substraction logic

### DIFF
--- a/src/operators.py
+++ b/src/operators.py
@@ -31,7 +31,7 @@ def subtract(a, b):
     Returns:
         float | int: Différence entre a et b (selon l'implémentation actuelle).
     """
-    return b - a
+    return a - b
 
 
 def multiply(a, b):


### PR DESCRIPTION
This branch fixes the subtraction logic in operators.py.

Problem:
The subtract(a, b) function was returning b - a instead of a - b,
causing incorrect results in both unit tests and calculate().

Fix:
Updated the implementation to return a - b.

Tests:
- test_subtract_basic now passes
- test_calculate_valid_expressions [10-4-6.0] now passes

All tests executed successfully with pytest.