### PR TITLE
PR3: Fix division to return floating-point results

### DIFF
--- a/src/operators.py
+++ b/src/operators.py
@@ -62,4 +62,4 @@ def divide(a, b):
     Notes:
         La division par zéro peut générer une exception Python.
     """
-    return a // b
+    return a / b


### PR DESCRIPTION
This branch fixes the division logic in operators.py.

Problem:
The divide(a, b) function was using integer division (//),
which truncates decimal values.

Fix:
Replaced a // b with a / b to ensure correct floating-point results.

Tests:
- test_divide_decimal_result now passes
- test_divide_basic remains valid
- test_divide_by_zero_raises remains valid

All tests pass successfully.