### PR TITLE
Fix incorrect button labels and missing operator symbols in UI

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -26,7 +26,7 @@
       <div class="buttons">
         <!-- Les boutons numériques ajoutent du texte à l'affichage via JavaScript -->
         <button type="button" class="btn" onclick="appendToDisplay('1')">1</button>
-        <button type="button" class="btn" onclick="appendToDisplay('2')">02</button>
+        <button type="button" class="btn" onclick="appendToDisplay('2')">2</button>
         <button type="button" class="btn" onclick="appendToDisplay('3')">3</button>
         <button type="button" class="btn operator" onclick="appendToDisplay('+')">+</button>
 
@@ -36,9 +36,9 @@
         <button type="button" class="btn operator" onclick="appendToDisplay('-')">-</button>
 
         <button type="button" class="btn" onclick="appendToDisplay('7')">7</button>
-        <button type="button" class="btn" onclick="appendToDisplay('8')">88</button>
+        <button type="button" class="btn" onclick="appendToDisplay('8')">8</button>
         <button type="button" class="btn" onclick="appendToDisplay('9')">9</button>
-        <button type="button" class="btn operator" onclick="appendToDisplay('*')"></button>
+        <button type="button" class="btn operator" onclick="appendToDisplay('*')">*</button>
 
         <button type="button" class="btn" onclick="appendToDisplay('0')">0</button>
 
@@ -48,7 +48,7 @@
         <!-- Bouton = : déclenche l'envoi du formulaire au backend -->
         <button type="submit" class="btn operator">=</button>
 
-        <button type="button" class="btn operator" onclick="appendToDisplay('/')"></button>
+        <button type="button" class="btn operator" onclick="appendToDisplay('/')">/</button>
       </div>
     </form>
   </div>


### PR DESCRIPTION
This branch fixes multiple display issues in `index.html`.

Problem:
Some calculator buttons were displaying incorrect or missing labels:

* The "2" button displayed `02`
* The "8" button displayed `88`
* The "*" and "/" operator buttons had no visible text

These issues impacted the usability and clarity of the interface.

Fix:

* Corrected the labels for buttons "2" and "8"
* Added the missing symbols for "*" and "/" operator buttons

Tests:

Manual UI verification performed in the browser
All backend automated tests (pytest) remain passing
No regression introduced

The calculator interface now displays all buttons correctly and remains fully functional.
